### PR TITLE
add support to MinGW (with bash ./build.sh)

### DIFF
--- a/platform/compilation/cust_rules.mk
+++ b/platform/compilation/cust_rules.mk
@@ -19,7 +19,7 @@ SHELL := /bin/bash
 # 	echo "#####  $(MAKELEVEL)  ########################################"     
 ifeq ($(MAKELEVEL),0)
 
-BUILD_HOST_TYPE_CMD := "case `uname` in Linux*) echo LINUX;; CYGWIN*) echo CYGWIN;; Windows*) echo WINDOWS;; *) echo UNKNOWN;; esac"
+BUILD_HOST_TYPE_CMD := "case `uname` in Linux*) echo LINUX;; CYGWIN*) echo CYGWIN;; MINGW*) echo CYGWIN;; Windows*) echo WINDOWS;; *) echo UNKNOWN;; esac"
 export BUILD_HOST_TYPE := $(shell sh -c $(BUILD_HOST_TYPE_CMD))
 
 ifeq "$(BUILD_HOST_TYPE)" "UNKNOWN"

--- a/platform/compilation/elfCombine.pl
+++ b/platform/compilation/elfCombine.pl
@@ -340,10 +340,12 @@ else
     dbg_out("1", "parameter ok");
 
     my $cwd = getcwd();
+    $input_elf_file_1 = abs_path($input_elf_file_1);
     my $index1 = index($input_elf_file_1,$cwd)+length($cwd)+1;
     my $index2 = length($input_elf_file_1);
     $input_elf_file_1 = substr($input_elf_file_1,$index1,$index2);
     # print "\n----$input_elf_file_1------\n";
+    $input_elf_file_2 = abs_path($input_elf_file_2);
     $index1 = index($input_elf_file_2,$cwd)+length($cwd)+1;
     $index2 = length($input_elf_file_2);
     $input_elf_file_2 = substr($input_elf_file_2,$index1,$index2);


### PR DESCRIPTION
With this changes you can build all proyects in MinGW (with bash from [git-scm](https://git-scm.com/download/win)).

You need add `~/.bashrc` file:

- in 64bit:
 ```bash
export PATH=$PATH:${GPRS_CSDTK42_PATH}/make64:${GPRS_CSDTK42_PATH}/mingw32/bin:${GPRS_CSDTK42_PATH}/cooltools:${GPRS_CSDTK42_PATH}/python27
export PATH=$PATH:${GPRS_CSDTK42_PATH}/mips-elf-4.4.2/bin:${GPRS_CSDTK42_PATH}/mips-rda-elf-7.1.0/bin:${GPRS_CSDTK42_PATH}/rv32-elf-5.4.1/bin
export LD_LIBRARY_PATH=${LD_LIBRARY_PATH}:${GPRS_CSDTK42_PATH}/cooltools/lib:${GPRS_CSDTK42_PATH}/mingw32/lib
```
- in 32bit (not tested):
 ```bash
export PATH=$PATH:${GPRS_CSDTK42_PATH}/make:${GPRS_CSDTK42_PATH}/mingw32/bin:${GPRS_CSDTK42_PATH}/cooltools:${GPRS_CSDTK42_PATH}/python27
export PATH=$PATH:${GPRS_CSDTK42_PATH}/mips-elf-4.4.2/bin:${GPRS_CSDTK42_PATH}/mips-rda-elf-7.1.0/bin:${GPRS_CSDTK42_PATH}/rv32-elf-5.4.1/bin
export LD_LIBRARY_PATH=${LD_LIBRARY_PATH}:${GPRS_CSDTK42_PATH}/cooltools/lib:${GPRS_CSDTK42_PATH}/mingw32/lib
```

This `~/.bashrc` file can be modifie or created in future versions of `setup.sh` from `CSDK42` (for windows).

Then you can execute for example (in bash of [git-scm](https://git-scm.com/download/win)):

```bash
$ ./build.sh demo gpio
```

I think that maintain only `build.sh` is simpler that maintain `build.bat` and `build.sh`...